### PR TITLE
Changed validation error binding

### DIFF
--- a/WPFValidationDisplayErrors/MainWindow.xaml
+++ b/WPFValidationDisplayErrors/MainWindow.xaml
@@ -18,7 +18,7 @@
         <Style x:Key="ToolTipWithErrorMessageOnErrorStyle" TargetType="TextBox" BasedOn="{StaticResource DefaultTextBoxStyle}">
             <Style.Triggers>
                 <Trigger Property="Validation.HasError" Value="True">
-                    <Setter Property="ToolTip" Value="{Binding RelativeSource={RelativeSource Self}, Path=(Validation.Errors)[0].ErrorContent}" />
+                    <Setter Property="ToolTip" Value="{Binding RelativeSource={RelativeSource Self}, Path=(Validation.Errors)/ErrorContent}" />
                 </Trigger>
             </Style.Triggers>
         </Style>
@@ -38,7 +38,7 @@
                         <StackPanel>
                             <AdornedElementPlaceholder x:Name="placeholder" />
                             <TextBlock FontSize="11" FontStyle="Italic" Foreground="Red" 
-                                       Text="{Binding ElementName=placeholder, Path=AdornedElement.(Validation.Errors)[0].ErrorContent}" />
+                                       Text="{Binding ElementName=placeholder, Path=AdornedElement.(Validation.Errors)/ErrorContent}" />
                         </StackPanel>
                     </ControlTemplate>
                 </Setter.Value>


### PR DESCRIPTION
(Validation.Errors).[0].ErrorContent will cause a binding error when the Errors collection is changed to empty. (Validation.Errors)/ErrorContent will avoid this problem.
Ref: https://stackoverflow.com/questions/2260616/why-does-wpf-style-to-show-validation-errors-in-tooltip-work-for-a-textbox-but-f